### PR TITLE
Add `--no-self-update` option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,13 @@ pub struct Config {
 
     #[serde(default)]
     pub proxy: Option<String>,
+
+    #[serde(default = "default_self_update")]
+    pub self_update: bool,
+}
+
+fn default_self_update() -> bool {
+    true
 }
 
 impl Config {
@@ -100,6 +107,7 @@ impl fmt::Display for Config {
         if let Some(x) = &self.proxy {
             ret.push_str(&format!("  proxy: {x}\n"));
         }
+        ret.push_str(&format!("  self_update: {}\n", self.self_update));
         ret.fmt(f)
     }
 }


### PR DESCRIPTION
Add `--no-self-update` option for environment that users of verylup don't have write permission of verylup binary.

Refs: https://github.com/iic-jku/IIC-OSIC-TOOLS/issues/139