### PR TITLE
Fix unexpectedly disabled self-update

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::fs;
 use std::path::PathBuf;
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
     #[serde(default)]
     pub default_toolchain: Option<String>,
@@ -109,5 +109,11 @@ impl fmt::Display for Config {
         }
         ret.push_str(&format!("  self_update: {}\n", self.self_update));
         ret.fmt(f)
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        toml::from_str("").unwrap_or_else(|_| Self::default())
     }
 }


### PR DESCRIPTION
#167 introduced `self_update` field to `Config`, but the default value was `false`.
So if `config.toml` doesn't exist, self-update feature is disabled.
This PR enables it by default.